### PR TITLE
Log files with failing specs

### DIFF
--- a/exe/multirspec
+++ b/exe/multirspec
@@ -12,7 +12,8 @@ coordinator = RSpec::MultiprocessRunner::Coordinator.new(
   {
     file_timeout_seconds: options.file_timeout_seconds,
     example_timeout_seconds: options.example_timeout_seconds,
-    rspec_options: options.rspec_options
+    rspec_options: options.rspec_options,
+    log_failing_files: options.log_failing_files
   }
 )
 
@@ -29,4 +30,9 @@ end
 
 success = coordinator.run
 
-exit(success ? 0 : 1)
+status = if options.log_failing_files
+  0
+else
+  success ? 0 : 1
+end
+exit(status)

--- a/lib/rspec/multiprocess_runner/command_line_options.rb
+++ b/lib/rspec/multiprocess_runner/command_line_options.rb
@@ -6,13 +6,14 @@ module RSpec::MultiprocessRunner
   # @private
   class CommandLineOptions
     attr_accessor :worker_count, :file_timeout_seconds, :example_timeout_seconds,
-      :rspec_options, :explicit_files_or_directories, :pattern
+      :rspec_options, :explicit_files_or_directories, :pattern, :log_failing_files
 
     def initialize
       self.worker_count = 3
       self.file_timeout_seconds = nil
       self.example_timeout_seconds = 15
       self.pattern = "**/*_spec.rb"
+      self.log_failing_files = false
       self.rspec_options = []
     end
 
@@ -85,6 +86,10 @@ module RSpec::MultiprocessRunner
 
         parser.on("-P", "--pattern PATTERN", "A glob to use to select files to run (#{print_default pattern})") do |pattern|
           self.pattern = pattern
+        end
+
+        parser.on("--log-failing-files", "Write failing spec files to multiprocess.failures") do |bool|
+          self.log_failing_files = bool
         end
 
         parser.on_tail("-h", "--help", "Prints this help") do

--- a/lib/rspec/multiprocess_runner/rake_task.rb
+++ b/lib/rspec/multiprocess_runner/rake_task.rb
@@ -52,6 +52,8 @@ module RSpec::MultiprocessRunner
     # rspec binary from the loaded rspec-core gem.
     attr_accessor :multirspec_path
 
+    attr_accessor :log_failing_files
+
     # Command line options to pass to the RSpec workers. Defaults to `nil`.
     attr_accessor :rspec_opts
 
@@ -106,6 +108,9 @@ module RSpec::MultiprocessRunner
       end
       if pattern
         cmd_parts << '--pattern' << pattern
+      end
+      if log_failing_files
+        cmd_parts << '--log-failing-files'
       end
       if files_or_directories
         cmd_parts.concat(files_or_directories)

--- a/lib/rspec/multiprocess_runner/worker.rb
+++ b/lib/rspec/multiprocess_runner/worker.rb
@@ -206,7 +206,8 @@ module RSpec::MultiprocessRunner
         example_status: example_status,
         description: description,
         line_number: line_number,
-        details: details
+        details: details,
+        file_path: @current_file
       )
     end
 
@@ -295,12 +296,13 @@ module RSpec::MultiprocessRunner
 
   # @private
   class ExampleResult
-    attr_reader :status, :description, :details, :time_finished
+    attr_reader :status, :description, :details, :file_path, :time_finished
 
     def initialize(example_complete_message)
       @status = example_complete_message["example_status"]
       @description = example_complete_message["description"]
       @details = example_complete_message["details"]
+      @file_path = example_complete_message["file_path"]
       @time_finished = Time.now
     end
   end

--- a/spec/rspec/multiprocess_runner/command_line_options_spec.rb
+++ b/spec/rspec/multiprocess_runner/command_line_options_spec.rb
@@ -96,6 +96,20 @@ module RSpec::MultiprocessRunner
         include_examples "no errors"
       end
 
+      describe 'with a log failing files flag' do
+        let(:arguments) { %w(--log-failing-files) }
+
+        it 'has the flag' do
+          expect(parsed.log_failing_files).to be_true
+        end
+
+        it "has no files" do
+          expect(parsed.explicit_files_or_directories).to be_nil
+        end
+
+        include_examples "no errors"
+      end
+
       describe "with only RSpec pass-through options" do
         let(:arguments) { %w(-- --backtrace -c) }
 

--- a/spec/rspec/multiprocess_runner/rake_task_spec.rb
+++ b/spec/rspec/multiprocess_runner/rake_task_spec.rb
@@ -83,6 +83,13 @@ module RSpec::MultiprocessRunner
       end
     end
 
+    context "with a log failing files flag" do
+      it 'is passed into the command' do
+        task.log_failing_files = true
+        expect(spec_command).to include_elements_in_order("--log-failing-files")
+      end
+    end
+
     context "with explicit files" do
       it "includes them in the command" do
         task.files_or_directories = %w(spec/models/soul_spec.rb spec/actions/sale_spec.rb)
@@ -96,6 +103,7 @@ module RSpec::MultiprocessRunner
         task.directories = %w(features)
         task.worker_count = 8
         task.file_timeout_seconds = 600
+        task.log_failing_files = true
         task.rspec_opts = "--backtrace"
 
         expect(spec_command).to eq([
@@ -104,6 +112,7 @@ module RSpec::MultiprocessRunner
           "--worker-count", "8",
           "--file-timeout", "600",
           "--pattern", "*.feature",
+          "--log-failing-files",
           "features",
           "--",
           "--backtrace"


### PR DESCRIPTION
The spec file path is now passed along with each message hash. If
--log-failing-files option is set, then the files will be written to a
log file. This way, the first general run never fails.