### PR TITLE
Refactor failed files logging

### DIFF
--- a/exe/multirspec
+++ b/exe/multirspec
@@ -30,9 +30,4 @@ end
 
 success = coordinator.run
 
-status = if options.log_failing_files
-  0
-else
-  success ? 0 : 1
-end
-exit(status)
+exit(success ? 0 : 1)

--- a/lib/rspec/multiprocess_runner/command_line_options.rb
+++ b/lib/rspec/multiprocess_runner/command_line_options.rb
@@ -13,7 +13,7 @@ module RSpec::MultiprocessRunner
       self.file_timeout_seconds = nil
       self.example_timeout_seconds = 15
       self.pattern = "**/*_spec.rb"
-      self.log_failing_files = false
+      self.log_failing_files = nil
       self.rspec_options = []
     end
 
@@ -88,8 +88,8 @@ module RSpec::MultiprocessRunner
           self.pattern = pattern
         end
 
-        parser.on("--log-failing-files", "Write failing spec files to multiprocess.failures") do |bool|
-          self.log_failing_files = bool
+        parser.on("--log-failing-files FILENAME", "Filename to log failing files to") do |filename|
+          self.log_failing_files = filename
         end
 
         parser.on_tail("-h", "--help", "Prints this help") do

--- a/lib/rspec/multiprocess_runner/coordinator.rb
+++ b/lib/rspec/multiprocess_runner/coordinator.rb
@@ -175,7 +175,6 @@ module RSpec::MultiprocessRunner
       by_status_and_time = combine_example_results.each_with_object({}) do |result, idx|
         (idx[result.status] ||= []) << result
       end
-      count_examples(by_status_and_time)
 
       print_skipped_files_details
       print_pending_example_details(by_status_and_time["pending"])
@@ -194,13 +193,6 @@ module RSpec::MultiprocessRunner
 
     def any_example_failed?
       (@workers + @stopped_workers).detect { |w| w.example_results.detect { |r| r.status == "failed" } }
-    end
-
-    def count_examples(example_results)
-      @metadata = {}
-      @metadata[:example_count] = example_results.map { |status, results| results.size }.inject(0) { |sum, ct| sum + ct }
-      @metadata[:failure_count] = example_results["failed"] ? example_results["failed"].size : 0
-      @metadata[:pending_count] = example_results["pending"] ? example_results["pending"].size : 0
     end
 
     def print_skipped_files_details
@@ -235,7 +227,6 @@ module RSpec::MultiprocessRunner
 
     def log_failed_files(failed_example_results)
       return if failed_example_results.nil?
-      return if failed_example_results.size > @metadata[:example_count] / 10.0
 
       failing_files = Hash.new { |h, k| h[k] = 0 }
       failed_example_results.each do |failure|
@@ -243,8 +234,8 @@ module RSpec::MultiprocessRunner
       end
 
       puts
-      puts "Writing failures to file: multiprocess.failures"
-      File.open("multiprocess.failures", "w+") do |io|
+      puts "Writing failures to file: #{@log_failing_files}"
+      File.open(@log_failing_files, "w+") do |io|
         failing_files.each do |(k, _)|
           io << k
           io << "\n"
@@ -258,13 +249,16 @@ module RSpec::MultiprocessRunner
     end
 
     def print_example_counts(by_status_and_time)
+      example_count = by_status_and_time.map { |status, results| results.size }.inject(0) { |sum, ct| sum + ct }
+      failure_count = by_status_and_time["failed"] ? by_status_and_time["failed"].size : 0
+      pending_count = by_status_and_time["pending"] ? by_status_and_time["pending"].size : 0
       process_failure_count = failed_workers.size
       skipped_count = @spec_files.size
 
       # Copied from RSpec
-      summary = pluralize(@metadata[:example_count], "example")
-      summary << ", " << pluralize(@metadata[:failure_count], "failure")
-      summary << ", #{@metadata[:pending_count]} pending" if @metadata[:pending_count] > 0
+      summary = pluralize(example_count, "example")
+      summary << ", " << pluralize(failure_count, "failure")
+      summary << ", #{pending_count} pending" if pending_count > 0
       summary << ", " << pluralize(process_failure_count, "failed proc") if process_failure_count > 0
       summary << ", " << pluralize(skipped_count, "skipped file") if skipped_count > 0
       puts summary

--- a/lib/rspec/multiprocess_runner/rake_task.rb
+++ b/lib/rspec/multiprocess_runner/rake_task.rb
@@ -110,7 +110,7 @@ module RSpec::MultiprocessRunner
         cmd_parts << '--pattern' << pattern
       end
       if log_failing_files
-        cmd_parts << '--log-failing-files'
+        cmd_parts << '--log-failing-files' << log_failing_files
       end
       if files_or_directories
         cmd_parts.concat(files_or_directories)

--- a/spec/rspec/multiprocess_runner/command_line_options_spec.rb
+++ b/spec/rspec/multiprocess_runner/command_line_options_spec.rb
@@ -96,11 +96,11 @@ module RSpec::MultiprocessRunner
         include_examples "no errors"
       end
 
-      describe 'with a log failing files flag' do
-        let(:arguments) { %w(--log-failing-files) }
+      describe 'with a log failing files option' do
+        let(:arguments) { %w(--log-failing-files logfile.name) }
 
-        it 'has the flag' do
-          expect(parsed.log_failing_files).to be_true
+        it 'has the file name' do
+          expect(parsed.log_failing_files).to eq("logfile.name")
         end
 
         it "has no files" do

--- a/spec/rspec/multiprocess_runner/rake_task_spec.rb
+++ b/spec/rspec/multiprocess_runner/rake_task_spec.rb
@@ -85,8 +85,8 @@ module RSpec::MultiprocessRunner
 
     context "with a log failing files flag" do
       it 'is passed into the command' do
-        task.log_failing_files = true
-        expect(spec_command).to include_elements_in_order("--log-failing-files")
+        task.log_failing_files = "afile.txt"
+        expect(spec_command).to include_elements_in_order("--log-failing-files", "afile.txt")
       end
     end
 
@@ -103,7 +103,7 @@ module RSpec::MultiprocessRunner
         task.directories = %w(features)
         task.worker_count = 8
         task.file_timeout_seconds = 600
-        task.log_failing_files = true
+        task.log_failing_files = "afile.txt"
         task.rspec_opts = "--backtrace"
 
         expect(spec_command).to eq([
@@ -112,7 +112,7 @@ module RSpec::MultiprocessRunner
           "--worker-count", "8",
           "--file-timeout", "600",
           "--pattern", "*.feature",
-          "--log-failing-files",
+          "--log-failing-files", "afile.txt",
           "features",
           "--",
           "--backtrace"


### PR DESCRIPTION
Issues addressed:
- Returns a consistent exit status instead of checking the failing files
  option
- Make the failing files log configurable
- Drop the early logging return behavior. This was complicating the exit
  status as noted in issue #8 and could be surprising. Closes #8