### PR TITLE
Disable RSpec's at_exit hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 0.4.1
 
+* Use RSpec::Core::Runner.disable_autorun! to avoid error messages when workers
+  finish
+
 # 0.4.0
 
 * Change TEST_ENV_NUMBER values to match parallel_tests (#10)

--- a/lib/rspec/multiprocess_runner/worker.rb
+++ b/lib/rspec/multiprocess_runner/worker.rb
@@ -86,6 +86,9 @@ module RSpec::MultiprocessRunner
         # prevent RSpec from trapping INT, also
         ::RSpec::Core::Runner.instance_eval { def self.trap_interrupt; end }
 
+        # Disable RSpec's at_exit hook that would try to run whatever is in ARGV
+        ::RSpec::Core::Runner.disable_autorun!
+
         set_process_name
         run_loop
       end


### PR DESCRIPTION
To prevent error messages at the end of the run.

https://github.com/cdd/rspec-multiprocess_runner/issues/11