### PR TITLE
Enable Master/Slaves Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A corresponding slave node, for a master on `master.local` would be:
 
     $ multirspec -H master.local -p 2222 -s [Files]
 
-N.B. If you must include the same files for the slaves as the master.
+N.B. You must include the same files for the slaves as the master.
 
 A corresponding set up for a slave node using SSH would be:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This gem provides a mechanism for running a suite of RSpec tests in multiple
 processes on the same machine and multiple machines (all reporting back to the
-head node), potentially allowing substantial performance improvements.
+head node [machine]), potentially allowing substantial performance improvements.
 
 It differs from `parallel_tests` in that it uses a coordinator process on each
 machine to manage the workers, hand off work to them, and receive results. These

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # Rspec::MultiprocessRunner
 
 This gem provides a mechanism for running a suite of RSpec tests in multiple
-processes on the same machine, potentially allowing substantial performance
-improvements.
+processes on the same machine and multiple machines (all reporting back to the
+master), potentially allowing substantial performance improvements.
 
-It differs from `parallel_tests` in that it uses a coordinator process to manage
-the workers, hand off work to them, and receive results. This means it can
-dynamically balance the workload among the processors. It also means it can
-provide consolidated results in the console.
+It differs from `parallel_tests` in that it uses a coordinator process on each
+machine to manage the workers, hand off work to them, and receive results. These
+coordinators communicate via simple TCP messages with a master coordinator to
+remain in sync when running on multiple machines. This means it can dynamically
+balance the workload among the processors and machines. It also means it can
+provide consolidated results in one console.
 
 It follows parallel_tests' environment variable conventions so it's easy to
 use them together. (E.g., parallel_tests has a very nice set of rake tasks
@@ -19,11 +21,14 @@ for setting up parallel environments.)
   time needed to run a suite. Even CPU-bound specs can be aided
 * Provides detailed logging of each example as it completes, including the
   failure message (you don't have to wait until the end to see the failure
-  reason).
+  reason). This is only on the machine running the spec, a final print out does
+  occur on the main machine upon completion, however.
 * Detects, kills, and reports spec files that take longer than expected (five
   minutes by default).
 * Detects and reports spec files that crash (without interrupting the
   remainder of the suite).
+* Master machine detects and reruns spec files that are not reported back by the
+  slaves.
 
 ## Limitations
 
@@ -37,6 +42,9 @@ for setting up parallel environments.)
 * Intermediate-quality code. Happy path works, and workers are
   managed/restarted, but:
   * There's no test coverage of the runner itself, only auxiliaries.
+* No security in the TCP messaging, but can work over SSH tunnels. Slaves do
+  verify the file name given against the known files so it will not execute
+  maliciously.
 
 ## Installation
 
@@ -74,6 +82,24 @@ In this case, each RSpec process would receive the options `-b -I ./lib`. Note
 that not that many RSpec options really make sense to pass this way. In
 particular, file selection and output formatting options are unlikely to work
 the way you expect.
+
+Runs as a master node by default. The following command mimics the defaults:
+
+    $ multirspec -p 2222 -n 5 [Files]
+
+A corresponding slave node, for a master on `master.local` would be:
+
+    $ multirspec -H master.local -p 2222 -s [Files]
+
+N.B. If you must include the same files for the slaves as the master.
+
+A corresponding set up for a slave node using SSH would be:
+
+    $ ssh -nNT -L 2500:localhost:2222 master.local &
+    $ multirspec -H localhost -p 2500 -s [Files]
+    $ kill $(jobs -p)
+
+N.B. Ensure that the master has tcp local port forwarding permitted.
 
 ### Rake
 

--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ Runs as a head node node by default. The following command mimics the defaults:
 
 A corresponding node node, for a head node on `head_node.local` would be:
 
-    $ multirspec -H head_node.local -p 2222 -s [Files]
+    $ multirspec -H head_node.local -p 2222 -n [Files]
 
 N.B. You must include the same files for the nodes as the head node.
 
 A corresponding set up for a node node using SSH would be:
 
     $ ssh -nNT -L 2500:localhost:2222 head_node.local &
-    $ multirspec -H localhost -p 2500 -s [Files]
+    $ multirspec -H localhost -p 2500 -n [Files]
     $ kill $(jobs -p)
 
 N.B. Ensure that the head node has tcp local port forwarding permitted.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This gem provides a mechanism for running a suite of RSpec tests in multiple
 processes on the same machine and multiple machines (all reporting back to the
-master), potentially allowing substantial performance improvements.
+head node), potentially allowing substantial performance improvements.
 
 It differs from `parallel_tests` in that it uses a coordinator process on each
 machine to manage the workers, hand off work to them, and receive results. These
-coordinators communicate via simple TCP messages with a master coordinator to
+coordinators communicate via simple TCP messages with a head node coordinator to
 remain in sync when running on multiple machines. This means it can dynamically
 balance the workload among the processors and machines. It also means it can
 provide consolidated results in one console.
@@ -27,8 +27,8 @@ for setting up parallel environments.)
   minutes by default).
 * Detects and reports spec files that crash (without interrupting the
   remainder of the suite).
-* Master machine detects and reruns spec files that are not reported back by the
-  slaves.
+* Head node detects and reruns spec files that are not reported back by the
+  nodes.
 
 ## Limitations
 
@@ -42,7 +42,7 @@ for setting up parallel environments.)
 * Intermediate-quality code. Happy path works, and workers are
   managed/restarted, but:
   * There's no test coverage of the runner itself, only auxiliaries.
-* No security in the TCP messaging, but can work over SSH tunnels. Slaves do
+* No security in the TCP messaging, but can work over SSH tunnels. Nodes do
   verify the file name given against the known files so it will not execute
   maliciously.
 
@@ -83,23 +83,23 @@ that not that many RSpec options really make sense to pass this way. In
 particular, file selection and output formatting options are unlikely to work
 the way you expect.
 
-Runs as a master node by default. The following command mimics the defaults:
+Runs as a head node node by default. The following command mimics the defaults:
 
     $ multirspec -p 2222 -n 5 [Files]
 
-A corresponding slave node, for a master on `master.local` would be:
+A corresponding node node, for a head node on `head_node.local` would be:
 
-    $ multirspec -H master.local -p 2222 -s [Files]
+    $ multirspec -H head_node.local -p 2222 -s [Files]
 
-N.B. You must include the same files for the slaves as the master.
+N.B. You must include the same files for the nodes as the head node.
 
-A corresponding set up for a slave node using SSH would be:
+A corresponding set up for a node node using SSH would be:
 
-    $ ssh -nNT -L 2500:localhost:2222 master.local &
+    $ ssh -nNT -L 2500:localhost:2222 head_node.local &
     $ multirspec -H localhost -p 2500 -s [Files]
     $ kill $(jobs -p)
 
-N.B. Ensure that the master has tcp local port forwarding permitted.
+N.B. Ensure that the head node has tcp local port forwarding permitted.
 
 ### Rake
 

--- a/exe/multirspec
+++ b/exe/multirspec
@@ -15,7 +15,10 @@ coordinator = RSpec::MultiprocessRunner::Coordinator.new(
     test_env_number_first_is_1: options.first_is_1,
     rspec_options: options.rspec_options,
     log_failing_files: options.log_failing_files,
-    use_given_order: options.use_given_order
+    use_given_order: options.use_given_order,
+    master: options.master,
+    port: options.port,
+    hostname: options.hostname
   }
 )
 

--- a/exe/multirspec
+++ b/exe/multirspec
@@ -18,7 +18,8 @@ coordinator = RSpec::MultiprocessRunner::Coordinator.new(
     use_given_order: options.use_given_order,
     master: options.master,
     port: options.port,
-    hostname: options.hostname
+    hostname: options.hostname,
+    max_slaves: options.max_slaves
   }
 )
 

--- a/exe/multirspec
+++ b/exe/multirspec
@@ -16,10 +16,10 @@ coordinator = RSpec::MultiprocessRunner::Coordinator.new(
     rspec_options: options.rspec_options,
     log_failing_files: options.log_failing_files,
     use_given_order: options.use_given_order,
-    master: options.master,
+    head_node: options.head_node,
     port: options.port,
     hostname: options.hostname,
-    max_slaves: options.max_slaves
+    max_nodes: options.max_nodes
   }
 )
 

--- a/lib/rspec/multiprocess_runner/command_line_options.rb
+++ b/lib/rspec/multiprocess_runner/command_line_options.rb
@@ -127,15 +127,15 @@ module RSpec::MultiprocessRunner
           self.port = port
         end
 
-        parser.on("-H", "--hostname HOSTNAME", "Hostname of head_node (#{print_default hostname})") do |hostname|
+        parser.on("-H", "--hostname HOSTNAME", "Hostname of the head node (#{print_default hostname})") do |hostname|
           self.hostname = hostname
         end
 
-        parser.on("-s", "--node", "This is a node process") do
+        parser.on("-n", "--node", "This node is controlled by a head node") do
           self.head_node = false
         end
 
-        parser.on("-n", "--num-max-nodes MAX_NODES", Integer, "Maximum number of nodes permitted (#{print_default max_nodes})") do |max_nodes|
+        parser.on("-m", "--max-nodes MAX_NODES", Integer, "Maximum number of nodes (excluding master) permitted (#{print_default max_nodes})") do |max_nodes|
           self.max_nodes = max_nodes
         end
 

--- a/lib/rspec/multiprocess_runner/command_line_options.rb
+++ b/lib/rspec/multiprocess_runner/command_line_options.rb
@@ -7,7 +7,7 @@ module RSpec::MultiprocessRunner
   class CommandLineOptions
     attr_accessor :worker_count, :file_timeout_seconds, :example_timeout_seconds,
       :rspec_options, :explicit_files_or_directories, :pattern, :log_failing_files,
-      :first_is_1, :use_given_order, :port, :master, :hostname, :max_slaves
+      :first_is_1, :use_given_order, :port, :head_node, :hostname, :max_nodes
 
     DEFAULT_WORKER_COUNT = 3
 
@@ -22,8 +22,8 @@ module RSpec::MultiprocessRunner
       self.use_given_order = false
       self.port = 2222
       self.hostname = "localhost"
-      self.master = true
-      self.max_slaves = 5
+      self.head_node = true
+      self.max_nodes = 5
     end
 
     def parse(command_line_args, error_stream=$stderr)
@@ -127,16 +127,16 @@ module RSpec::MultiprocessRunner
           self.port = port
         end
 
-        parser.on("-H", "--hostname HOSTNAME", "Hostname of master (#{print_default hostname})") do |hostname|
+        parser.on("-H", "--hostname HOSTNAME", "Hostname of head_node (#{print_default hostname})") do |hostname|
           self.hostname = hostname
         end
 
-        parser.on("-s", "--slave", "This is a slave process") do
-          self.master = false
+        parser.on("-s", "--node", "This is a node process") do
+          self.head_node = false
         end
 
-        parser.on("-n", "--num-max-slaves MAX_SLAVES", Integer, "Maximum number of slaves permitted (#{print_default max_slaves})") do |max_slaves|
-          self.max_slaves = max_slaves
+        parser.on("-n", "--num-max-nodes MAX_NODES", Integer, "Maximum number of nodes permitted (#{print_default max_nodes})") do |max_nodes|
+          self.max_nodes = max_nodes
         end
 
         parser.on_tail("-h", "--help", "Prints this help") do

--- a/lib/rspec/multiprocess_runner/command_line_options.rb
+++ b/lib/rspec/multiprocess_runner/command_line_options.rb
@@ -127,7 +127,7 @@ module RSpec::MultiprocessRunner
           self.port = port
         end
 
-        parser.on("-H", "--hostname HOSTNAME", "Hostname for master machines (#{print_default hostname})") do |hostname|
+        parser.on("-H", "--hostname HOSTNAME", "Hostname of master (#{print_default hostname})") do |hostname|
           self.hostname = hostname
         end
 

--- a/lib/rspec/multiprocess_runner/command_line_options.rb
+++ b/lib/rspec/multiprocess_runner/command_line_options.rb
@@ -7,7 +7,7 @@ module RSpec::MultiprocessRunner
   class CommandLineOptions
     attr_accessor :worker_count, :file_timeout_seconds, :example_timeout_seconds,
       :rspec_options, :explicit_files_or_directories, :pattern, :log_failing_files,
-      :first_is_1, :use_given_order, :port, :master, :hostname
+      :first_is_1, :use_given_order, :port, :master, :hostname, :max_slaves
 
     DEFAULT_WORKER_COUNT = 3
 
@@ -23,6 +23,7 @@ module RSpec::MultiprocessRunner
       self.port = 2222
       self.hostname = "localhost"
       self.master = true
+      self.max_slaves = 5
     end
 
     def parse(command_line_args, error_stream=$stderr)
@@ -132,6 +133,10 @@ module RSpec::MultiprocessRunner
 
         parser.on("-s", "--slave", "This is a slave process") do
           self.master = false
+        end
+
+        parser.on("-n", "--num-max-slaves MAX_SLAVES", "Maximum number of slaves permitted (#{print_default max_slaves})") do |max_slaves|
+          self.max_slaves = max_slaves
         end
 
         parser.on_tail("-h", "--help", "Prints this help") do

--- a/lib/rspec/multiprocess_runner/command_line_options.rb
+++ b/lib/rspec/multiprocess_runner/command_line_options.rb
@@ -7,7 +7,7 @@ module RSpec::MultiprocessRunner
   class CommandLineOptions
     attr_accessor :worker_count, :file_timeout_seconds, :example_timeout_seconds,
       :rspec_options, :explicit_files_or_directories, :pattern, :log_failing_files,
-      :first_is_1, :use_given_order
+      :first_is_1, :use_given_order, :port, :master, :hostname
 
     DEFAULT_WORKER_COUNT = 3
 
@@ -20,6 +20,9 @@ module RSpec::MultiprocessRunner
       self.rspec_options = []
       self.first_is_1 = default_first_is_1
       self.use_given_order = false
+      self.port = 2222
+      self.hostname = "localhost"
+      self.master = true
     end
 
     def parse(command_line_args, error_stream=$stderr)
@@ -117,6 +120,18 @@ module RSpec::MultiprocessRunner
 
         parser.on("-O", "--use-given-order", "Use the order that the files are given as arguments") do
           self.use_given_order = true
+        end
+
+        parser.on("-p", "--port PORT", "Communicate using port (#{print_default port})") do |port|
+          self.port = port
+        end
+
+        parser.on("-h", "--hostname HOSTNAME", "Hostname for master machines (#{print_default hostname})") do |hostname|
+          self.hostname = hostname
+        end
+
+        parser.on("-s", "--slave", "This is a slave process") do
+          self.master = false
         end
 
         parser.on_tail("-h", "--help", "Prints this help") do

--- a/lib/rspec/multiprocess_runner/command_line_options.rb
+++ b/lib/rspec/multiprocess_runner/command_line_options.rb
@@ -123,11 +123,11 @@ module RSpec::MultiprocessRunner
           self.use_given_order = true
         end
 
-        parser.on("-p", "--port PORT", "Communicate using port (#{print_default port})") do |port|
+        parser.on("-p", "--port PORT", Integer, "Communicate using port (#{print_default port})") do |port|
           self.port = port
         end
 
-        parser.on("-h", "--hostname HOSTNAME", "Hostname for master machines (#{print_default hostname})") do |hostname|
+        parser.on("-H", "--hostname HOSTNAME", "Hostname for master machines (#{print_default hostname})") do |hostname|
           self.hostname = hostname
         end
 
@@ -135,7 +135,7 @@ module RSpec::MultiprocessRunner
           self.master = false
         end
 
-        parser.on("-n", "--num-max-slaves MAX_SLAVES", "Maximum number of slaves permitted (#{print_default max_slaves})") do |max_slaves|
+        parser.on("-n", "--num-max-slaves MAX_SLAVES", Integer, "Maximum number of slaves permitted (#{print_default max_slaves})") do |max_slaves|
           self.max_slaves = max_slaves
         end
 

--- a/lib/rspec/multiprocess_runner/coordinator.rb
+++ b/lib/rspec/multiprocess_runner/coordinator.rb
@@ -24,7 +24,7 @@ module RSpec::MultiprocessRunner
       expected_worker_numbers.each do |n|
         create_and_start_worker_if_necessary(n)
       end
-      (0..1).each do
+      (0..1).each do # rerun files missing from disconnects
         run_loop
         quit_all_workers
         @file_coordinator.finished
@@ -42,7 +42,7 @@ module RSpec::MultiprocessRunner
       exit_code = 0
       exit_code |= 1 if any_example_failed?
       exit_code |= 2 if !failed_workers.empty?
-      exit_code |= 4 if work_left_to_do?
+      exit_code |= 4 if work_left_to_do? || @file_coordinator.missing_files.any?
       exit_code
     end
 

--- a/lib/rspec/multiprocess_runner/coordinator.rb
+++ b/lib/rspec/multiprocess_runner/coordinator.rb
@@ -2,6 +2,7 @@
 require 'rspec/multiprocess_runner'
 require 'rspec/multiprocess_runner/worker'
 require 'rspec/multiprocess_runner/file_coordinator'
+require 'pry'
 
 module RSpec::MultiprocessRunner
   class Coordinator
@@ -211,8 +212,8 @@ module RSpec::MultiprocessRunner
 
     def print_summary
       elapsed = Time.now - @start_time
-      by_status_and_time = combine_example_results.each_with_object({}) do |result, idx|
-        (idx[result.status] ||= []) << result
+      by_status_and_time = combine_example_results.each_with_object(Hash.new { |h, k| h[k] = [] }) do |result, idx|
+        idx[result.status] << result
       end
 
       print_skipped_files_details

--- a/lib/rspec/multiprocess_runner/coordinator.rb
+++ b/lib/rspec/multiprocess_runner/coordinator.rb
@@ -24,7 +24,10 @@ module RSpec::MultiprocessRunner
       expected_worker_numbers.each do |n|
         create_and_start_worker_if_necessary(n)
       end
-      2.times do # rerun files missing from disconnects
+      run_loop
+      quit_all_workers
+      @file_coordinator.finished
+      if @file_coordinator.missing_files.any?
         run_loop
         quit_all_workers
         @file_coordinator.finished

--- a/lib/rspec/multiprocess_runner/coordinator.rb
+++ b/lib/rspec/multiprocess_runner/coordinator.rb
@@ -219,7 +219,7 @@ module RSpec::MultiprocessRunner
       print_pending_example_details(by_status_and_time["pending"])
       print_failed_example_details(by_status_and_time["failed"])
       print_missing_files
-      log_failed_files(by_status_and_time["failed"].map(&:file_path).uniq  + @file_coordinator.missing_files) if @log_failing_files
+      log_failed_files(by_status_and_time["failed"].map(&:file_path).uniq  + @file_coordinator.missing_files.to_a) if @log_failing_files
       print_failed_process_details
       puts
       print_elapsed_time(elapsed)

--- a/lib/rspec/multiprocess_runner/coordinator.rb
+++ b/lib/rspec/multiprocess_runner/coordinator.rb
@@ -24,7 +24,7 @@ module RSpec::MultiprocessRunner
       expected_worker_numbers.each do |n|
         create_and_start_worker_if_necessary(n)
       end
-      (0..1).each do # rerun files missing from disconnects
+      2.times do # rerun files missing from disconnects
         run_loop
         quit_all_workers
         @file_coordinator.finished

--- a/lib/rspec/multiprocess_runner/coordinator.rb
+++ b/lib/rspec/multiprocess_runner/coordinator.rb
@@ -308,7 +308,7 @@ module RSpec::MultiprocessRunner
       puts
       puts "Failed processes:"
       failed_workers.each do |worker|
-        puts "  - #{worker.slave}:#{worker.pid} (env #{worker.environment_number}) #{worker.deactivation_reason} on #{worker.current_file}"
+        puts "  - #{worker.node}:#{worker.pid} (env #{worker.environment_number}) #{worker.deactivation_reason} on #{worker.current_file}"
       end
     end
 
@@ -316,7 +316,7 @@ module RSpec::MultiprocessRunner
       return if @file_coordinator.missing_files.empty?
       puts
       puts "Missing files from disconnects:"
-      @file_coordinator.missing_files.each { |file| puts "  + #{file} was given to a slave, which disconnected" }
+      @file_coordinator.missing_files.each { |file| puts "  + #{file} was given to a node, which disconnected" }
     end
 
     def print_elapsed_time(seconds_elapsed)

--- a/lib/rspec/multiprocess_runner/coordinator.rb
+++ b/lib/rspec/multiprocess_runner/coordinator.rb
@@ -2,7 +2,6 @@
 require 'rspec/multiprocess_runner'
 require 'rspec/multiprocess_runner/worker'
 require 'rspec/multiprocess_runner/file_coordinator'
-require 'pry'
 
 module RSpec::MultiprocessRunner
   class Coordinator

--- a/lib/rspec/multiprocess_runner/file_coordinator.rb
+++ b/lib/rspec/multiprocess_runner/file_coordinator.rb
@@ -1,30 +1,60 @@
 # encoding: utf-8
 require 'rspec/multiprocess_runner'
 require 'socket'
+require 'pry'
 
 module RSpec::MultiprocessRunner
   class FileCoordinator
+    attr_reader :results
+
+    COMMAND_FILE = "file"
+    COMMAND_RESULTS = "results"
+    COMMAND_FINISHED = "finished"
+
     def initialize(files, options={})
       @spec_files = []
+      @results = []
+      @threads = []
       @spec_files_reference = files.to_set
       @hostname = options[:hostname]
       @port = options[:port]
-      if options[:master]
+      @max_threads = options[:max_slaves]
+      @master = options[:master]
+      if @master
         @spec_files = options[:use_given_order] ? files : sort_files(files)
-        Thread.start {run_server}
+        Thread.start { run_server }
       end
+      count = 100
+      while @tcp_socket.nil? do
+        begin
+          @tcp_socket = TCPSocket.new @hostname, @port
+        rescue
+          raise if count < 0
+          count--
+          sleep(6)
+        end
+      end
+      ObjectSpace.define_finalizer( self, proc { @tcp_socket.close } )
     end
 
     def remaining_files
       @spec_files
     end
 
+    def missing_files
+      if @master
+        @spec_files_reference - @results.map(&:file_path)
+      else
+        []
+      end
+    end
+
     def get_file
       begin
-        socket = TCPSocket.new @hostname, @port
-        file = socket.gets.strip
-        socket.close
-        if true || (@spec_files_reference.include? file)
+        socket = @tcp_socket
+        socket.puts [COMMAND_FILE].to_json
+        file = socket.gets.chomp
+        if @spec_files_reference.include? file
           return file
         else
           return nil # Malformed response, assume done, cease function
@@ -32,6 +62,19 @@ module RSpec::MultiprocessRunner
       rescue
         return nil # If Error, assume done, cease function
       end
+    end
+
+    def send_results(results)
+      begin
+        socket = @tcp_socket
+        socket.puts [COMMAND_RESULTS, results].to_json
+      rescue
+      end
+    end
+
+    def finished
+      @tcp_socket.puts [COMMAND_FINISHED].to_json
+      @threads.each(&:join)
     end
 
     private
@@ -45,13 +88,23 @@ module RSpec::MultiprocessRunner
       files.sort_by { |file| -File.size(file) }
     end
 
-
     def run_server
       server = TCPServer.new @port
-      loop do
-        Thread.start(server.accept) do |client|
-          if work_left_to_do?
-            client.puts @spec_files.shift
+      while @threads.size < @max_threads
+        @threads << Thread.start(server.accept) do |client|
+          begin
+            loop do
+              response = JSON.parse(client.gets)
+              if response[0] == COMMAND_RESULTS && results = response[1].map { |result|
+                ExampleResult.from_json_parse(result) }
+                @results += results
+              elsif response[0] == COMMAND_FILE
+                client.puts @spec_files.shift
+              elsif response[0] == COMMAND_FINISHED
+                break
+              end
+            end
+          rescue
           end
           client.close
         end

--- a/lib/rspec/multiprocess_runner/file_coordinator.rb
+++ b/lib/rspec/multiprocess_runner/file_coordinator.rb
@@ -109,15 +109,15 @@ module RSpec::MultiprocessRunner
       loop do
         raw_response = socket.gets
         break unless raw_response
-        response = JSON.parse(raw_response)
-        if response[0] == COMMAND_RESULTS && results = response[1].map { |result|
+        command, results, slave = JSON.parse(raw_response)
+        if command == COMMAND_RESULTS && results = results.map { |result|
           ExampleResult.from_json_parse(result) }
           @results += results
-        elsif response[0] == COMMAND_PROCESS && response[1]
-          @failed_workers << MockWorker.from_json_parse(response[1], response[2] || unknown)
-        elsif response[0] == COMMAND_FILE
+        elsif command == COMMAND_PROCESS && results
+          @failed_workers << MockWorker.from_json_parse(results, slave || "unknown")
+        elsif command == COMMAND_FILE
           socket.puts @spec_files.shift
-        elsif response[0] == COMMAND_FINISHED
+        elsif command == COMMAND_FINISHED
           break
         end
       end

--- a/lib/rspec/multiprocess_runner/file_coordinator.rb
+++ b/lib/rspec/multiprocess_runner/file_coordinator.rb
@@ -30,7 +30,7 @@ module RSpec::MultiprocessRunner
           @tcp_socket = TCPSocket.new @hostname, @port
         rescue
           raise if count < 0
-          count--
+          count -= 1
           sleep(6)
         end
       end

--- a/lib/rspec/multiprocess_runner/file_coordinator.rb
+++ b/lib/rspec/multiprocess_runner/file_coordinator.rb
@@ -90,6 +90,7 @@ module RSpec::MultiprocessRunner
 
     def run_server
       server = TCPServer.new @port
+      ObjectSpace.define_finalizer( self, proc { server.close } )
       while @threads.size < @max_threads
         @threads << Thread.start(server.accept) do |client|
           begin

--- a/lib/rspec/multiprocess_runner/file_coordinator.rb
+++ b/lib/rspec/multiprocess_runner/file_coordinator.rb
@@ -28,7 +28,6 @@ module RSpec::MultiprocessRunner
         @slave_socket, master_socket = Socket.pair(:UNIX, :STREAM)
         Thread.start { server_connection_established(master_socket) }
       else
-        print "connecting to server"
         count = 100
         while @slave_socket.nil? do
           begin
@@ -38,7 +37,6 @@ module RSpec::MultiprocessRunner
             @slave_socket = nil
             raise if count < 0
             count -= 1
-            print '.'
             sleep(6)
           end
         end

--- a/lib/rspec/multiprocess_runner/file_coordinator.rb
+++ b/lib/rspec/multiprocess_runner/file_coordinator.rb
@@ -121,7 +121,6 @@ module RSpec::MultiprocessRunner
           break
         end
       end
-      socket.close
     end
 
     def work_left_to_do?

--- a/lib/rspec/multiprocess_runner/file_coordinator.rb
+++ b/lib/rspec/multiprocess_runner/file_coordinator.rb
@@ -1,0 +1,65 @@
+# encoding: utf-8
+require 'rspec/multiprocess_runner'
+require 'socket'
+
+module RSpec::MultiprocessRunner
+  class FileCoordinator
+    def initialize(files, options={})
+      @spec_files = []
+      @spec_files_reference = files.to_set
+      @hostname = options[:hostname]
+      @port = options[:port]
+      if options[:master]
+        @spec_files = options[:use_given_order] ? files : sort_files(files)
+        Thread.start {run_server}
+      end
+    end
+
+    def remaining_files
+      @spec_files
+    end
+
+    def get_file
+      begin
+        socket = TCPSocket.new @hostname, @port
+        file = socket.gets.strip
+        socket.close
+        if true || (@spec_files_reference.include? file)
+          return file
+        else
+          return nil # Malformed response, assume done, cease function
+        end
+      rescue
+        return nil # If Error, assume done, cease function
+      end
+    end
+
+    private
+
+    # Sorting by decreasing size attempts to ensure we don't send the slowest
+    # file to a worker right before all the other workers finish and then end up
+    # waiting for that one process to finish.
+    # In the future it would be nice to log execution time and sort by that.
+    def sort_files(files)
+      # #sort_by caches the File.size result so we only call it once per file.
+      files.sort_by { |file| -File.size(file) }
+    end
+
+
+    def run_server
+      server = TCPServer.new @port
+      loop do
+        Thread.start(server.accept) do |client|
+          if work_left_to_do?
+            client.puts @spec_files.shift
+          end
+          client.close
+        end
+      end
+    end
+
+    def work_left_to_do?
+      !@spec_files.empty?
+    end
+  end
+end

--- a/lib/rspec/multiprocess_runner/rake_task.rb
+++ b/lib/rspec/multiprocess_runner/rake_task.rb
@@ -138,11 +138,8 @@ module RSpec::MultiprocessRunner
       if use_given_order
         cmd_parts << '--use-given-order'
       end
-      if files_or_directories
-        cmd_parts.concat(files_or_directories)
-      end
       if port
-        cmd_parts << '--port' << port
+        cmd_parts << '--port' << port.to_s
       end
       if slave
         cmd_parts << '--slave'
@@ -151,7 +148,10 @@ module RSpec::MultiprocessRunner
         cmd_parts << '--hostname' << hostname
       end
       if max_slaves
-        cmd_parts << '--num-max-slaves' << max_slaves
+        cmd_parts << '--num-max-slaves' << max_slaves.to_s
+      end
+      if files_or_directories
+        cmd_parts.concat(files_or_directories)
       end
       if rspec_opts
         cmd_parts << '--'

--- a/lib/rspec/multiprocess_runner/rake_task.rb
+++ b/lib/rspec/multiprocess_runner/rake_task.rb
@@ -68,14 +68,14 @@ module RSpec::MultiprocessRunner
     # Port to use for TCP communication. Defaults to `2222`.
     attr_accessor :port
 
-    # Be a slave to a master at hostname. Defaults to `false`
-    attr_accessor :slave
+    # Be a node to a head_node at hostname. Defaults to `false`
+    attr_accessor :node
 
     # Hostname where server is running. Defaults to `localhost`
     attr_accessor :hostname
 
-    # Max number of connections to master. Defaults to `5`
-    attr_accessor :max_slaves
+    # Max number of connections to head_node. Defaults to `5`
+    attr_accessor :max_nodes
 
     def initialize(*args, &task_block)
       @name            = args.shift || :multispec
@@ -141,14 +141,14 @@ module RSpec::MultiprocessRunner
       if port
         cmd_parts << '--port' << port.to_s
       end
-      if slave
-        cmd_parts << '--slave'
+      if node
+        cmd_parts << '--node'
       end
       if hostname
         cmd_parts << '--hostname' << hostname
       end
-      if max_slaves
-        cmd_parts << '--num-max-slaves' << max_slaves.to_s
+      if max_nodes
+        cmd_parts << '--num-max-nodes' << max_nodes.to_s
       end
       if files_or_directories
         cmd_parts.concat(files_or_directories)

--- a/lib/rspec/multiprocess_runner/rake_task.rb
+++ b/lib/rspec/multiprocess_runner/rake_task.rb
@@ -65,6 +65,15 @@ module RSpec::MultiprocessRunner
     # Command line options to pass to the RSpec workers. Defaults to `nil`.
     attr_accessor :rspec_opts
 
+    # Port to use for TCP communication. Defaults to `2222`.
+    attr_accessor :port
+
+    # Be a slave to a master at hostname. Defaults to `false`
+    attr_accessor :slave
+
+    # Hostname where server is running. Defaults to `localhost`
+    attr_accessor :hostname
+
     def initialize(*args, &task_block)
       @name            = args.shift || :multispec
       @verbose         = true
@@ -128,6 +137,15 @@ module RSpec::MultiprocessRunner
       end
       if files_or_directories
         cmd_parts.concat(files_or_directories)
+      end
+      if port
+        cmd_parts << '--port' << port
+      end
+      if slave
+        cmd_parts << '--slave'
+      end
+      if hostname
+        cmd_parts << '--hostname' << hostname
       end
       if rspec_opts
         cmd_parts << '--'

--- a/lib/rspec/multiprocess_runner/rake_task.rb
+++ b/lib/rspec/multiprocess_runner/rake_task.rb
@@ -74,6 +74,9 @@ module RSpec::MultiprocessRunner
     # Hostname where server is running. Defaults to `localhost`
     attr_accessor :hostname
 
+    # Max number of connections to master. Defaults to `5`
+    attr_accessor :max_slaves
+
     def initialize(*args, &task_block)
       @name            = args.shift || :multispec
       @verbose         = true
@@ -146,6 +149,9 @@ module RSpec::MultiprocessRunner
       end
       if hostname
         cmd_parts << '--hostname' << hostname
+      end
+      if max_slaves
+        cmd_parts << '--num-max-slaves' << max_slaves
       end
       if rspec_opts
         cmd_parts << '--'

--- a/lib/rspec/multiprocess_runner/rake_task.rb
+++ b/lib/rspec/multiprocess_runner/rake_task.rb
@@ -68,10 +68,10 @@ module RSpec::MultiprocessRunner
     # Port to use for TCP communication. Defaults to `2222`.
     attr_accessor :port
 
-    # Be a node to a head_node at hostname. Defaults to `false`
-    attr_accessor :node
+    # Be a node to a head node at hostname. Defaults to `false`
+    attr_accessor :head_node
 
-    # Hostname where server is running. Defaults to `localhost`
+    # Hostname of head node. Defaults to `localhost`
     attr_accessor :hostname
 
     # Max number of connections to head_node. Defaults to `5`
@@ -148,7 +148,7 @@ module RSpec::MultiprocessRunner
         cmd_parts << '--hostname' << hostname
       end
       if max_nodes
-        cmd_parts << '--num-max-nodes' << max_nodes.to_s
+        cmd_parts << '--max-nodes' << max_nodes.to_s
       end
       if files_or_directories
         cmd_parts.concat(files_or_directories)

--- a/lib/rspec/multiprocess_runner/rake_task.rb
+++ b/lib/rspec/multiprocess_runner/rake_task.rb
@@ -69,7 +69,7 @@ module RSpec::MultiprocessRunner
     attr_accessor :port
 
     # Be a node to a head node at hostname. Defaults to `false`
-    attr_accessor :head_node
+    attr_accessor :node
 
     # Hostname of head node. Defaults to `localhost`
     attr_accessor :hostname

--- a/lib/rspec/multiprocess_runner/worker.rb
+++ b/lib/rspec/multiprocess_runner/worker.rb
@@ -305,18 +305,18 @@ module RSpec::MultiprocessRunner
   end
 
   class MockWorker
-    attr_reader :pid, :environment_number, :current_file, :deactivation_reason, :slave
+    attr_reader :pid, :environment_number, :current_file, :deactivation_reason, :node
 
-    def initialize(hash, slave)
+    def initialize(hash, node)
       @pid = hash["pid"]
       @environment_number = hash["environment_number"]
       @current_file = hash["current_file"]
       @deactivation_reason = hash["deactivation_reason"]
-      @slave = slave
+      @node = node
     end
 
-    def self.from_json_parse(hash, slave)
-      MockWorker.new(hash, slave)
+    def self.from_json_parse(hash, node)
+      MockWorker.new(hash, node)
     end
   end
 

--- a/lib/rspec/multiprocess_runner/worker.rb
+++ b/lib/rspec/multiprocess_runner/worker.rb
@@ -19,6 +19,22 @@ module RSpec::MultiprocessRunner
   #   actually run specs.
   #
   # @private
+  class MockWorker
+    attr_reader :pid, :environment_number, :current_file, :deactivation_reason, :slave
+
+    def initialize(hash, slave)
+      @pid = hash["pid"]
+      @environment_number = hash["environment_number"]
+      @current_file = hash["current_file"]
+      @deactivation_reason = hash["deactivation_reason"]
+      @slave = slave
+    end
+
+    def self.from_json_parse(hash, slave)
+      MockWorker.new(hash, slave)
+    end
+  end
+
   class Worker
     attr_reader :pid, :environment_number, :example_results, :current_file
     attr_accessor :deactivation_reason
@@ -144,6 +160,10 @@ module RSpec::MultiprocessRunner
 
     def receive_and_act_on_message_from_worker
       act_on_message_from_worker(receive_message_from_worker)
+    end
+
+    def to_json(options = nil)
+      { "pid" => @pid, "environment_number" => @environment_number, "current_file" => @current_file, "deactivation_reason" => @deactivation_reason }.to_json
     end
 
     private

--- a/lib/rspec/multiprocess_runner/worker.rb
+++ b/lib/rspec/multiprocess_runner/worker.rb
@@ -19,22 +19,6 @@ module RSpec::MultiprocessRunner
   #   actually run specs.
   #
   # @private
-  class MockWorker
-    attr_reader :pid, :environment_number, :current_file, :deactivation_reason, :slave
-
-    def initialize(hash, slave)
-      @pid = hash["pid"]
-      @environment_number = hash["environment_number"]
-      @current_file = hash["current_file"]
-      @deactivation_reason = hash["deactivation_reason"]
-      @slave = slave
-    end
-
-    def self.from_json_parse(hash, slave)
-      MockWorker.new(hash, slave)
-    end
-  end
-
   class Worker
     attr_reader :pid, :environment_number, :example_results, :current_file
     attr_accessor :deactivation_reason
@@ -317,6 +301,22 @@ module RSpec::MultiprocessRunner
 
     def send_message(socket, message_hash)
       socket.puts(message_hash.to_json)
+    end
+  end
+
+  class MockWorker
+    attr_reader :pid, :environment_number, :current_file, :deactivation_reason, :slave
+
+    def initialize(hash, slave)
+      @pid = hash["pid"]
+      @environment_number = hash["environment_number"]
+      @current_file = hash["current_file"]
+      @deactivation_reason = hash["deactivation_reason"]
+      @slave = slave
+    end
+
+    def self.from_json_parse(hash, slave)
+      MockWorker.new(hash, slave)
     end
   end
 

--- a/lib/rspec/multiprocess_runner/worker.rb
+++ b/lib/rspec/multiprocess_runner/worker.rb
@@ -304,12 +304,21 @@ module RSpec::MultiprocessRunner
   class ExampleResult
     attr_reader :status, :description, :details, :file_path, :time_finished
 
-    def initialize(example_complete_message)
+    def initialize(example_complete_message, time = Time.now)
+      @hash = example_complete_message
       @status = example_complete_message["example_status"]
       @description = example_complete_message["description"]
       @details = example_complete_message["details"]
       @file_path = example_complete_message["file_path"]
-      @time_finished = Time.now
+      @time_finished = time
+    end
+
+    def to_json(options = nil)
+      { hash: @hash, time: @time_finished.iso8601(9) }.to_json
+    end
+
+    def self.from_json_parse(hash)
+      ExampleResult.new(hash["hash"], Time.iso8601(hash["time"]))
     end
   end
 end

--- a/spec/rspec/multiprocess_runner/command_line_options_spec.rb
+++ b/spec/rspec/multiprocess_runner/command_line_options_spec.rb
@@ -7,7 +7,7 @@ module RSpec::MultiprocessRunner
     let(:parsed) { CommandLineOptions.new.parse(arguments, error_stream) }
 
     describe '#parse' do
-      shared_examples "the default timeout time and number of processes" do
+      shared_examples "the default timeout time and number of processes and networking" do
         it "uses 3 processes" do
           expect(parsed.worker_count).to eq(3)
         end
@@ -18,6 +18,22 @@ module RSpec::MultiprocessRunner
 
         it "has a 15 second per-example timeout" do
           expect(parsed.example_timeout_seconds).to eq(15)
+        end
+
+        it "has no slave flag" do
+          expect(parsed.master).to be_truthy
+        end
+
+        it "has no hostname flag" do
+          expect(parsed.hostname).to eq("localhost")
+        end
+
+        it "has no port flag" do
+          expect(parsed.port).to eq(2222)
+        end
+
+        it "has no num-max-slaves flag" do
+          expect(parsed.max_slaves).to eq(5)
         end
       end
 
@@ -31,7 +47,7 @@ module RSpec::MultiprocessRunner
       describe "by default" do
         let(:arguments) { [] }
 
-        include_examples "the default timeout time and number of processes"
+        include_examples "the default timeout time and number of processes and networking"
         include_examples "no errors"
 
         it "has no files or directories" do
@@ -56,12 +72,12 @@ module RSpec::MultiprocessRunner
           expect(parsed.explicit_files_or_directories).to eq(arguments)
         end
 
-        include_examples "the default timeout time and number of processes"
+        include_examples "the default timeout time and number of processes and networking"
         include_examples "no errors"
       end
 
       describe "with options" do
-        let(:arguments) { %w(-w 12 --file-timeout 1200 --example-timeout 67 --first-is-1 --use-given-order) }
+        let(:arguments) { %w(-w 12 --file-timeout 1200 --example-timeout 67 --first-is-1 --use-given-order --slave --hostname bob --port 8000 --num-max-slaves 2) }
 
         it "has the process count" do
           expect(parsed.worker_count).to eq(12)
@@ -85,6 +101,22 @@ module RSpec::MultiprocessRunner
 
         it "has the use-given-order flag" do
           expect(parsed.use_given_order).to be_truthy
+        end
+
+        it "has the slave flag" do
+          expect(parsed.master).to be_falsey
+        end
+
+        it "has the hostname flag" do
+          expect(parsed.hostname).to eq("bob")
+        end
+
+        it "has the port flag" do
+          expect(parsed.port).to eq(8000)
+        end
+
+        it "has the num-max-slaves flag" do
+          expect(parsed.max_slaves).to eq(2)
         end
 
         include_examples "no errors"
@@ -125,7 +157,7 @@ module RSpec::MultiprocessRunner
           expect(parsed.rspec_options).to eq(%w(--backtrace -c))
         end
 
-        include_examples "the default timeout time and number of processes"
+        include_examples "the default timeout time and number of processes and networking"
         include_examples "no errors"
       end
 

--- a/spec/rspec/multiprocess_runner/command_line_options_spec.rb
+++ b/spec/rspec/multiprocess_runner/command_line_options_spec.rb
@@ -20,8 +20,8 @@ module RSpec::MultiprocessRunner
           expect(parsed.example_timeout_seconds).to eq(15)
         end
 
-        it "has no slave flag" do
-          expect(parsed.master).to be_truthy
+        it "has no node flag" do
+          expect(parsed.head_node).to be_truthy
         end
 
         it "has no hostname flag" do
@@ -32,8 +32,8 @@ module RSpec::MultiprocessRunner
           expect(parsed.port).to eq(2222)
         end
 
-        it "has no num-max-slaves flag" do
-          expect(parsed.max_slaves).to eq(5)
+        it "has no num-max-nodes flag" do
+          expect(parsed.max_nodes).to eq(5)
         end
       end
 
@@ -77,7 +77,7 @@ module RSpec::MultiprocessRunner
       end
 
       describe "with options" do
-        let(:arguments) { %w(-w 12 --file-timeout 1200 --example-timeout 67 --first-is-1 --use-given-order --slave --hostname bob --port 8000 --num-max-slaves 2) }
+        let(:arguments) { %w(-w 12 --file-timeout 1200 --example-timeout 67 --first-is-1 --use-given-order --node --hostname bob --port 8000 --num-max-nodes 2) }
 
         it "has the process count" do
           expect(parsed.worker_count).to eq(12)
@@ -103,8 +103,8 @@ module RSpec::MultiprocessRunner
           expect(parsed.use_given_order).to be_truthy
         end
 
-        it "has the slave flag" do
-          expect(parsed.master).to be_falsey
+        it "has the node flag" do
+          expect(parsed.head_node).to be_falsey
         end
 
         it "has the hostname flag" do
@@ -115,8 +115,8 @@ module RSpec::MultiprocessRunner
           expect(parsed.port).to eq(8000)
         end
 
-        it "has the num-max-slaves flag" do
-          expect(parsed.max_slaves).to eq(2)
+        it "has the num-max-nodes flag" do
+          expect(parsed.max_nodes).to eq(2)
         end
 
         include_examples "no errors"

--- a/spec/rspec/multiprocess_runner/command_line_options_spec.rb
+++ b/spec/rspec/multiprocess_runner/command_line_options_spec.rb
@@ -77,7 +77,7 @@ module RSpec::MultiprocessRunner
       end
 
       describe "with options" do
-        let(:arguments) { %w(-w 12 --file-timeout 1200 --example-timeout 67 --first-is-1 --use-given-order --node --hostname bob --port 8000 --num-max-nodes 2) }
+        let(:arguments) { %w(-w 12 --file-timeout 1200 --example-timeout 67 --first-is-1 --use-given-order --node --hostname bob --port 8000 --max-nodes 2) }
 
         it "has the process count" do
           expect(parsed.worker_count).to eq(12)

--- a/spec/rspec/multiprocess_runner/rake_task_spec.rb
+++ b/spec/rspec/multiprocess_runner/rake_task_spec.rb
@@ -140,7 +140,7 @@ module RSpec::MultiprocessRunner
     context "with the max nodes flag" do
       it "is passed into the comand" do
         task.max_nodes = 2
-        expect(spec_command).to include_elements_in_order("--num-max-nodes", "2")
+        expect(spec_command).to include_elements_in_order("--max-nodes", "2")
       end
     end
 
@@ -171,7 +171,7 @@ module RSpec::MultiprocessRunner
           "--port", "8000",
           "--node",
           "--hostname", "bob",
-          "--num-max-nodes", "2",
+          "--max-nodes", "2",
           "features",
           "--",
           "--backtrace"

--- a/spec/rspec/multiprocess_runner/rake_task_spec.rb
+++ b/spec/rspec/multiprocess_runner/rake_task_spec.rb
@@ -123,10 +123,10 @@ module RSpec::MultiprocessRunner
       end
     end
 
-    context "with the slave flag" do
+    context "with the node flag" do
       it "is passed into the comand" do
-        task.slave = true
-        expect(spec_command).to include_elements_in_order("--slave")
+        task.node = true
+        expect(spec_command).to include_elements_in_order("--node")
       end
     end
 
@@ -137,10 +137,10 @@ module RSpec::MultiprocessRunner
       end
     end
 
-    context "with the max slaves flag" do
+    context "with the max nodes flag" do
       it "is passed into the comand" do
-        task.max_slaves = 2
-        expect(spec_command).to include_elements_in_order("--num-max-slaves", "2")
+        task.max_nodes = 2
+        expect(spec_command).to include_elements_in_order("--num-max-nodes", "2")
       end
     end
 
@@ -154,9 +154,9 @@ module RSpec::MultiprocessRunner
         task.first_is_1 = true
         task.use_given_order = true
         task.port = 8000
-        task.slave = true
+        task.node = true
         task.hostname = "bob"
-        task.max_slaves = 2
+        task.max_nodes = 2
         task.rspec_opts = "--backtrace"
 
         expect(spec_command).to eq([
@@ -169,9 +169,9 @@ module RSpec::MultiprocessRunner
           "--log-failing-files", "afile.txt",
           "--use-given-order",
           "--port", "8000",
-          "--slave",
+          "--node",
           "--hostname", "bob",
-          "--num-max-slaves", "2",
+          "--num-max-nodes", "2",
           "features",
           "--",
           "--backtrace"

--- a/spec/rspec/multiprocess_runner/rake_task_spec.rb
+++ b/spec/rspec/multiprocess_runner/rake_task_spec.rb
@@ -116,6 +116,34 @@ module RSpec::MultiprocessRunner
       end
     end
 
+    context "with the port flag" do
+      it "is passed into the comand" do
+        task.port = 8000
+        expect(spec_command).to include_elements_in_order("--port", "8000")
+      end
+    end
+
+    context "with the slave flag" do
+      it "is passed into the comand" do
+        task.slave = true
+        expect(spec_command).to include_elements_in_order("--slave")
+      end
+    end
+
+    context "with the hostname flag" do
+      it "is passed into the comand" do
+        task.hostname = "bob"
+        expect(spec_command).to include_elements_in_order("--hostname", "bob")
+      end
+    end
+
+    context "with the max slaves flag" do
+      it "is passed into the comand" do
+        task.max_slaves = 2
+        expect(spec_command).to include_elements_in_order("--num-max-slaves", "2")
+      end
+    end
+
     context "with everything" do
       it "has all the arguments in an order that will work" do
         task.pattern = "*.feature"
@@ -125,6 +153,10 @@ module RSpec::MultiprocessRunner
         task.log_failing_files = "afile.txt"
         task.first_is_1 = true
         task.use_given_order = true
+        task.port = 8000
+        task.slave = true
+        task.hostname = "bob"
+        task.max_slaves = 2
         task.rspec_opts = "--backtrace"
 
         expect(spec_command).to eq([
@@ -136,6 +168,10 @@ module RSpec::MultiprocessRunner
           "--pattern", "*.feature",
           "--log-failing-files", "afile.txt",
           "--use-given-order",
+          "--port", "8000",
+          "--slave",
+          "--hostname", "bob",
+          "--num-max-slaves", "2",
           "features",
           "--",
           "--backtrace"


### PR DESCRIPTION
Provides for tcp communication between a master and slave machines for faster testing.
All reports go back to the Master for analysis.  Any missing files from disconnects are rerun at the end.  If somehow there are still missing files, appropriate error reporting occurs.
Uses Unix sockets instead of TCP for master machine communication.