### PR TITLE
Add 'output' to log_failed_files call and parameters.

### DIFF
--- a/lib/rspec/multiprocess_runner/coordinator.rb
+++ b/lib/rspec/multiprocess_runner/coordinator.rb
@@ -204,7 +204,7 @@ module RSpec::MultiprocessRunner
     end
 
     def summary_file
-      File.new(options.summary_filename, 'w') if (options.summary_filename)      
+      File.new(options.summary_filename, 'w') if (options.summary_filename)
     end
 
     def print_summary
@@ -213,7 +213,7 @@ module RSpec::MultiprocessRunner
         idx[result.status] << result
       end
 
-      outputs = [STDOUT, summary_file].compact
+      outputs = [$stdout, summary_file].compact
       outputs.each do |output|
         print_skipped_files_details(output)
         print_pending_example_details(output, by_status_and_time["pending"])
@@ -225,7 +225,7 @@ module RSpec::MultiprocessRunner
         print_elapsed_time(output, elapsed)
         output.puts failed? ? "FAILURE" : "SUCCESS"
         print_example_counts(output, by_status_and_time)
-        output.close unless output == STDOUT
+        output.close unless output == $stdout
       end
     end
 

--- a/spec/rspec/multiprocess_runner/coordinator_spec.rb
+++ b/spec/rspec/multiprocess_runner/coordinator_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require 'byebug'
 require_relative '../../spec_helper'
 require 'rspec/multiprocess_runner/coordinator'
 
@@ -24,6 +23,10 @@ describe RSpec::MultiprocessRunner::Coordinator do
 
     it "should work" do
       expect(coordinator.run).to eq(0)
+    end
+
+    it "should generate output to STDOUT" do
+      expect{ coordinator.run }.to output(/0 examples/).to_stdout
     end
 
     it "should work with a summary file" do

--- a/spec/rspec/multiprocess_runner/coordinator_spec.rb
+++ b/spec/rspec/multiprocess_runner/coordinator_spec.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+require 'byebug'
+require_relative '../../spec_helper'
+require 'rspec/multiprocess_runner/coordinator'
+
+describe RSpec::MultiprocessRunner::Coordinator do
+  describe '.run' do
+    let(:worker_count) { 1 }
+    let(:files) { [] }
+    let(:log_failing_files) { 'log_failing_files' }
+    let(:options) { double('options', {head_node: true, use_given_order: true, worker_count: 1, summary_filename: nil, log_failing_files: 'log_failing_files'}) }
+    let(:coordinator) { RSpec::MultiprocessRunner::Coordinator.new(worker_count, files, options) }
+
+    around(:each) do |example|
+      File.delete(log_failing_files) if File.exist?(log_failing_files)
+      example.run
+      File.delete(log_failing_files) if File.exist?(log_failing_files)
+    end
+
+    before(:each) do
+      file_coordinator = double('FileCoordinator', {get_file: nil, finished: nil, remaining_files: [], results: [], missing_files: [], failed_workers: []} )
+      allow(RSpec::MultiprocessRunner::FileCoordinator).to receive(:new) { file_coordinator }
+    end
+
+    it "should work" do
+      expect(coordinator.run).to eq(0)
+    end
+
+    it "should work with a summary file" do
+      string_file = StringIO.new
+      expect(coordinator).to receive(:summary_file) { string_file }
+      expect(coordinator.run).to eq(0)
+      expect(string_file.string).to match(/0 examples/)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rspec/multiprocess_runner'
 require 'rspec/core/sandbox'
 require 'stub_env'
+require 'byebug'
 
 Dir['./spec/support/**/*.rb'].map {|f| require f}
 


### PR DESCRIPTION
Add a test that failed and now works.
