### PR TITLE
Do not proceed when you encounter an error outside of tests

### DIFF
--- a/lib/rspec/multiprocess_runner/file_coordinator.rb
+++ b/lib/rspec/multiprocess_runner/file_coordinator.rb
@@ -69,7 +69,8 @@ module RSpec::MultiprocessRunner
         else
           return nil # Malformed response, assume done, cease function
         end
-      rescue
+      rescue Exception => e
+        puts("Got exception #{e} in get_file")
         return nil # If Error, assume done, cease function
       end
     end

--- a/lib/rspec/multiprocess_runner/worker.rb
+++ b/lib/rspec/multiprocess_runner/worker.rb
@@ -263,9 +263,9 @@ module RSpec::MultiprocessRunner
     def act_on_message_from_coordinator(message_hash)
       return handle_closed_coordinator_socket unless message_hash # EOF
       case message_hash["command"]
-      when "quit"
+      when COMMAND_QUIT
         exit
-      when "run_file"
+      when COMMAND_RUN_FILE
         execute_spec(message_hash["filename"])
       else
         $stderr.puts "Received unsupported command #{message_hash["command"].inspect} in worker #{pid}"
@@ -282,6 +282,7 @@ module RSpec::MultiprocessRunner
 
       ReportingFormatter.worker = self
       RSpec::Core::Runner.run(@rspec_arguments + [spec_file])
+      raise "Error outside of tests on #{spec_file}" if RSpec.world.non_example_failure
       send_message_to_coordinator(status: STATUS_RUN_COMPLETE, filename: spec_file)
     ensure
       @current_file = nil

--- a/spec/features/exit_code_specs.rb
+++ b/spec/features/exit_code_specs.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'timeout'
 
 describe 'Exit code' do
   let(:executable) { 'ruby -Ilib exe/multirspec' }
@@ -27,15 +28,15 @@ describe 'Exit code' do
   end
 
   context 'on broken followed by success' do
-    let(:files) { 'spec/files/valid_but_broken.rb', 'spec/files/successful.rb' }
+    let(:files) { 'spec/files/valid_but_broken.rb spec/files/successful.rb' }
 
-    it { is_expected.to eq(1) }
+    it { is_expected.to eq(2) }
   end
 
   context 'on success followed by broken' do
-    let(:files) { 'spec/files/successful.rb', 'spec/files/valid_but_broken.rb' }
+    let(:files) { 'spec/files/successful.rb spec/files/valid_but_broken.rb' }
 
-    it { is_expected.to eq(1) }
+    it { is_expected.to eq(2) }
   end
 
   context 'on process failures' do

--- a/spec/features/exit_code_specs.rb
+++ b/spec/features/exit_code_specs.rb
@@ -26,6 +26,18 @@ describe 'Exit code' do
     it { is_expected.to eq(1) }
   end
 
+  context 'on broken followed by success' do
+    let(:files) { 'spec/files/valid_but_broken.rb', 'spec/files/successful.rb' }
+
+    it { is_expected.to eq(1) }
+  end
+
+  context 'on success followed by broken' do
+    let(:files) { 'spec/files/successful.rb', 'spec/files/valid_but_broken.rb' }
+
+    it { is_expected.to eq(1) }
+  end
+
   context 'on process failures' do
     let(:files) { 'spec/files/syntax_error.rb' }
 

--- a/spec/files/valid_but_broken.rb
+++ b/spec/files/valid_but_broken.rb
@@ -1,0 +1,5 @@
+describe ThisConstantIsMissing do
+  it "will never reach here" do
+    expect(true).to be_falsey
+  end
+end


### PR DESCRIPTION
The change in Worker will keep the tests from passing.
This is enough to stop the bleeding.