### PR TITLE
Fix outide specs error handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/docker_release.sh
+++ b/docker_release.sh
@@ -5,7 +5,7 @@ CONTROL_PATH=$(grep ControlPath /root/.ssh/config | awk '{ print $2 }' | xargs d
 mkdir -p ${CONTROL_PATH/#~/$HOME}
 
 # use the most modern bundle available to allow OTP
-gem install bundle
+gem install bundler
 bundle update --bundler
 
 bash

--- a/lib/rspec/multiprocess_runner/reporting_formatter.rb
+++ b/lib/rspec/multiprocess_runner/reporting_formatter.rb
@@ -60,7 +60,11 @@ module RSpec::MultiprocessRunner
     end
 
     def message(struct)
+      # this is just for reporting errors not otherwise reported
+      return unless RSpec.world.non_example_failure
+
       message = struct.message
+      # skip these as they always come after an error is seems
       return if message =~ /^No examples found./
 
       worker.report_error(message)

--- a/spec/features/exit_code_spec.rb
+++ b/spec/features/exit_code_spec.rb
@@ -45,6 +45,12 @@ describe 'Exit code' do
     it { is_expected.to eq(0) }
   end
 
+  context 'when a message other than an error comes through' do
+    let(:files) { 'spec/files/focus.rb' }
+
+    it { is_expected.to eq(0) }
+  end
+
   context 'on process failures' do
     let(:files) { 'spec/files/syntax_error.rb' }
 

--- a/spec/files/focus.rb
+++ b/spec/files/focus.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.filter_run focus: true
+end
+
+describe 'focus spec' do
+  it 'should mention focus in a message' do
+    expect(true).to be_truthy
+  end
+end


### PR DESCRIPTION
Report only when RSpec indicates there was an error
Also adds some docker niceness, including being able to more easily
release the gem